### PR TITLE
Automatic retry with exponential backoff

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -8,7 +8,6 @@ class FCM
   FORMAT = :json
 
   # constants
-  GROUP_NOTIFICATION_BASE_URI = 'https://android.googleapis.com'
   INSTANCE_ID_API = 'https://iid.googleapis.com'
   TOPIC_REGEX = /[a-zA-Z0-9\-_.~%]+/
 
@@ -49,8 +48,8 @@ class FCM
       'project_id' => project_id
     }
 
-    for_uri(GROUP_NOTIFICATION_BASE_URI, extra_headers) do |connection|
-      response = connection.post('/gcm/notification', post_body.to_json)
+    for_uri(BASE_URI, extra_headers) do |connection|
+      response = connection.post('/fcm/notification', post_body.to_json)
       build_response(response)
     end
   end
@@ -65,8 +64,8 @@ class FCM
       'project_id' => project_id
     }
 
-    for_uri(GROUP_NOTIFICATION_BASE_URI, extra_headers) do |connection|
-      response = connection.post('/gcm/notification', post_body.to_json)
+    for_uri(BASE_URI, extra_headers) do |connection|
+      response = connection.post('/fcm/notification', post_body.to_json)
       build_response(response)
     end
   end
@@ -81,8 +80,8 @@ class FCM
       'project_id' => project_id
     }
 
-    for_uri(GROUP_NOTIFICATION_BASE_URI, extra_headers) do |connection|
-      response = connection.post('/gcm/notification', post_body.to_json)
+    for_uri(BASE_URI, extra_headers) do |connection|
+      response = connection.post('/fcm/notification', post_body.to_json)
       build_response(response)
     end
   end
@@ -99,8 +98,8 @@ class FCM
       'project_id' => project_id
     }
 
-    for_uri(GROUP_NOTIFICATION_BASE_URI, extra_headers) do |connection|
-      response = connection.get('/gcm/notification', params)
+    for_uri(BASE_URI, extra_headers) do |connection|
+      response = connection.get('/fcm/notification', params)
       build_response(response)
     end
   end

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -45,14 +45,7 @@ class FCM
     post_body = build_post_body(registration_ids, operation: 'create',
                                 notification_key_name: key_name)
 
-    extra_headers = {
-      'project_id' => project_id
-    }
-
-    for_uri(BASE_URI, extra_headers) do |connection|
-      response = connection.post('/fcm/notification', post_body.to_json)
-      build_response(response)
-    end
+    update_group_messaging_setting(post_body, project_id)
   end
   alias create create_notification_key
 
@@ -61,14 +54,7 @@ class FCM
                                 notification_key_name: key_name,
                                 notification_key: notification_key)
 
-    extra_headers = {
-      'project_id' => project_id
-    }
-
-    for_uri(BASE_URI, extra_headers) do |connection|
-      response = connection.post('/fcm/notification', post_body.to_json)
-      build_response(response)
-    end
+    update_group_messaging_setting(post_body, project_id)
   end
   alias add add_registration_ids
 
@@ -77,14 +63,7 @@ class FCM
                                 notification_key_name: key_name,
                                 notification_key: notification_key)
 
-    extra_headers = {
-      'project_id' => project_id
-    }
-
-    for_uri(BASE_URI, extra_headers) do |connection|
-      response = connection.post('/fcm/notification', post_body.to_json)
-      build_response(response)
-    end
+    update_group_messaging_setting(post_body, project_id)
   end
   alias remove remove_registration_ids
 
@@ -251,6 +230,17 @@ class FCM
       end
     end
     not_registered_ids
+  end
+
+  def update_group_messaging_setting(body, project_id)
+    extra_headers = {
+      'project_id' => project_id
+    }
+    
+    for_uri(BASE_URI, extra_headers) do |connection|
+        response = connection.post('/fcm/notification', body.to_json)
+        build_response(response)
+    end
   end
 
   def execute_notification(body)

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe FCM do
   let(:send_url) { "#{FCM::BASE_URI}/fcm/send" }
-  let(:group_notification_base_uri) { "#{FCM::GROUP_NOTIFICATION_BASE_URI}/gcm/notification" }
+  let(:group_notification_base_uri) { "#{FCM::BASE_URI}/fcm/notification" }
   let(:api_key) { 'AIzaSyB-1uEai2WiUapxCs2Q0GZYzPu7Udno5aA' }
   let(:registration_id) { '42' }
   let(:registration_ids) { ['42'] }

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -369,7 +369,7 @@ describe FCM do
           body = error_response_body if i == 1
           body = valid_response_body if i == 0
           i += 1
-          {status: status, headers: { "Retry-After": "1"}, body: body.to_json}
+          {status: status, headers: { :"Retry-After" => "1"}, body: body.to_json}
         end
       end
 

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -90,7 +90,7 @@ describe FCM do
         stub_request(:post, send_url)
           .with(body: '{"registration_ids":["42"],"data":{"score":"5x1","time":"15:10"}}',
                 headers: valid_request_headers)
-          .to_return(status: 200, body: '', headers: {})
+          .to_return(status: 200, body: '{}', headers: {})
       end
       before do
       end
@@ -106,13 +106,13 @@ describe FCM do
         stub_request(:post, send_url)
           .with(body: '{"to":"/topics/TopicA","data":{"score":"5x1","time":"15:10"}}',
                 headers: valid_request_headers)
-          .to_return(status: 200, body: '', headers: {})
+          .to_return(status: 200, body: '{}', headers: {})
       end
       let!(:stub_with_invalid_topic) do
         stub_request(:post, send_url)
           .with(body: '{"condition":"/topics/TopicA$","data":{"score":"5x1","time":"15:10"}}',
                 headers: valid_request_headers)
-          .to_return(status: 200, body: '', headers: {})
+          .to_return(status: 200, body: '{}', headers: {})
       end
 
       describe "#send_to_topic" do
@@ -135,19 +135,19 @@ describe FCM do
         stub_request(:post, send_url)
           .with(body: '{"condition":"\'TopicA\' in topics && (\'TopicB\' in topics || \'TopicC\' in topics)","data":{"score":"5x1","time":"15:10"}}',
                 headers: valid_request_headers)
-          .to_return(status: 200, body: '', headers: {})
+          .to_return(status: 200, body: '{}', headers: {})
       end
       let!(:stub_with_invalid_condition) do
         stub_request(:post, send_url)
           .with(body: '{"condition":"\'TopicA\' in topics and some other text (\'TopicB\' in topics || \'TopicC\' in topics)","data":{"score":"5x1","time":"15:10"}}',
                 headers: valid_request_headers)
-          .to_return(status: 200, body: '', headers: {})
+          .to_return(status: 200, body: '{}', headers: {})
       end
       let!(:stub_with_invalid_condition_topic) do
         stub_request(:post, send_url)
           .with(body: '{"condition":"\'TopicA$\' in topics","data":{"score":"5x1","time":"15:10"}}',
                 headers: valid_request_headers)
-          .to_return(status: 200, body: '', headers: {})
+          .to_return(status: 200, body: '{}', headers: {})
       end
 
       describe "#send_to_topic_condition" do
@@ -336,6 +336,50 @@ describe FCM do
           response: 'success',
           body: '{"canonical_ids":0,"failure":1,"results":[{"error":"NotRegistered"}]}'
         )
+      end
+    end
+
+    context 'when send_notification responds with 5XX or 200+error:unavailable' do
+      subject { FCM.new(api_key) }
+
+      let(:valid_response_body) do
+        {
+          failure: 0, canonical_ids: 0, results: [{ message_id: '0:1385025861956342%572c22801bb3' }]
+        }
+      end
+
+      let(:error_response_body) do
+        {
+          failure: 1, canonical_ids: 0, results: [{ error: 'Unavailable' }]
+        }
+      end
+
+
+      let(:stub_fcm_send_request_unavaible_server) do
+        i = 0
+        stub_request(:post, send_url).with(
+          body: "{\"registration_ids\":[\"42\"]}",
+          headers: {
+       	  'Accept'=>'*/*',
+       	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+       	  'User-Agent'=>'Faraday v0.15.4'
+        }).to_return do |stub|
+          body = {}
+          status = ( i == 0) ? 501 : 200
+          body = error_response_body if i == 1
+          body = valid_response_body if i == 0
+          i += 1
+          {status: status, headers: { "Retry-After": "1"}, body: body.to_json}
+        end
+      end
+
+      before(:each) do
+        stub_fcm_send_request_unavaible_server
+      end
+
+      it 'should retry 2 times' do
+        subject.send( registration_ids)
+        stub_fcm_send_request_unavaible_server.should have_been_made.times(3)
       end
     end
   end


### PR DESCRIPTION
Implemented it using the recently added gem Faraday, when it is status 5xx or 200 and any of the results form body is error:Unavaible, it will retry the whole request, with an exponential interval.
passed on simple rspec test with webmock stubs.
I'm not sure if those interval params where good the exponential backoff.

Also updated group notification url to fcm url. https://github.com/spacialdb/fcm/issues/56

## ToDo
Implement a Retry faraday middleware that allow editing the body of the request before resend it, so when it is 200 + error:unavaible, we can resend it only for the registration_ids that failed, instead to sending for all.