### PR TITLE
Remove HTTParty example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ Example sending notifications:
 require 'fcm'
 
 fcm = FCM.new("my_server_key")
-# you can set option parameters in here
-#  - all options are pass to HTTParty method arguments
-#  - ref: https://github.com/jnunemaker/httparty/blob/master/lib/httparty.rb#L29-L60
-#  fcm = FCM.new("my_server_key", timeout: 3)
 
 registration_ids= ["12", "13"] # an array of one or more client registration tokens
 


### PR DESCRIPTION
Since https://github.com/decision-labs/fcm/pull/55 you can't pass client options anymore (well you can but they aren't used for anything).

This results in https://github.com/decision-labs/fcm/issues/84 which I'm +1 on, but while it's not resolved, better to not imply anything in the docs.