### PR TITLE
Relax faraday dependency

### DIFF
--- a/fcm.gemspec
+++ b/fcm.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency('faraday', '~> 1.3')
+  s.add_runtime_dependency('faraday', '~> 1')
 end


### PR DESCRIPTION
Related to #88 we can relax faraday version. It permits to use last release (actually 1.4.1) and will be compatible with next minor updates which should keeps the compatibility.