### PR TITLE
Accept any IO object for credentials

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -328,6 +328,10 @@ class FCM
   end
 
   def json_key
-    @json_key ||= (@json_key_path.respond_to?(:read) ? @json_key_path : File.open(@json_key_path))
+    @json_key ||= if @json_key_path.respond_to?(:read)
+      @json_key_path
+    else
+      File.open(@json_key_path)
+    end
   end
 end

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -329,9 +329,9 @@ class FCM
 
   def json_key
     @json_key ||= if @json_key_path.respond_to?(:read)
-      @json_key_path
-    else
-      File.open(@json_key_path)
-    end
+                    @json_key_path
+                  else
+                    File.open(@json_key_path)
+                  end
   end
 end

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -320,10 +320,14 @@ class FCM
   def jwt_token
     scope = "https://www.googleapis.com/auth/firebase.messaging"
     authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
-      json_key_io: File.open(@json_key_path),
+      json_key_io: json_key,
       scope: scope,
     )
     token = authorizer.fetch_access_token!
     token["access_token"]
+  end
+
+  def json_key
+    @json_key ||= (@json_key_path.respond_to?(:read) ? @json_key_path : File.open(@json_key_path))
   end
 end

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -498,4 +498,16 @@ describe FCM do
   describe "subscribing to a topic" do
     # TODO
   end
+
+  describe "credentials path" do
+    it "can be a path to a file" do
+      fcm = FCM.new("test", "README.md")
+      expect(fcm.__send__(:json_key).class).to eq(File)
+    end
+
+    it "can be an IO object" do
+      fcm = FCM.new("test", StringIO.new("hey"))
+      expect(fcm.__send__(:json_key).class).to eq(StringIO)
+    end
+  end
 end


### PR DESCRIPTION
This allows passing in credentials either as a file path or IO object. Useful if you're storing your credentials in ENV or Rails credentials for example.

```ruby
FCM.new("test", "creds.json")
FCM.new("test", StringIO.new("example"))
FCM.new("test", Rails.application.credentials.dig(:google, :credentials))
```