### PR TITLE
Make use of the timeout constant

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -224,7 +224,10 @@ class FCM
   private
 
   def for_uri(uri, extra_headers = {})
-    connection = ::Faraday.new(:url => uri, :request => { timeout: DEFAULT_TIMEOUT }) do |faraday|
+    connection = ::Faraday.new(
+      url: uri,
+      request: { timeout: DEFAULT_TIMEOUT }
+    ) do |faraday|
       faraday.adapter Faraday.default_adapter
       faraday.headers["Content-Type"] = "application/json"
       faraday.headers["Authorization"] = "key=#{api_key}"

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -224,7 +224,7 @@ class FCM
   private
 
   def for_uri(uri, extra_headers = {})
-    connection = ::Faraday.new(:url => uri) do |faraday|
+    connection = ::Faraday.new(:url => uri, :request => { timeout: DEFAULT_TIMEOUT }) do |faraday|
       faraday.adapter Faraday.default_adapter
       faraday.headers["Content-Type"] = "application/json"
       faraday.headers["Authorization"] = "key=#{api_key}"


### PR DESCRIPTION
The default timeout constant wasn't being used. Added it to the Faraday connection.