### PR TITLE
Fix issue with `get_instance_id_info` option params

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -188,9 +188,7 @@ class FCM
   end
 
   def get_instance_id_info(iid_token, options = {})
-    params = {
-      query: options,
-    }
+    params = options
 
     for_uri(INSTANCE_ID_API) do |connection|
       response = connection.get("/iid/info/" + iid_token, params)

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -503,13 +503,13 @@ describe FCM do
     subject(:get_info) { client.get_instance_id_info(registration_id, options) }
 
     let(:options) { nil }
-    let(:client) { FCM.new("TEST_SERVER_KEY") }
+    let(:client) { FCM.new('TEST_SERVER_KEY') }
     let(:base_uri) { "#{FCM::INSTANCE_ID_API}/iid/info" }
     let(:uri) { "#{base_uri}/#{registration_id}" }
     let(:mock_request_attributes) do
       { headers: {
-          'Authorization' => 'key=TEST_SERVER_KEY',
-          'Content-Type' => 'application/json'
+        'Authorization' => 'key=TEST_SERVER_KEY',
+        'Content-Type' => 'application/json'
       } }
     end
 

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -499,6 +499,43 @@ describe FCM do
     # TODO
   end
 
+  describe "getting instance info" do
+    subject(:get_instance_info) { client.get_instance_id_info(registration_id, options) }
+
+    let(:options) { nil }
+    let(:client) { FCM.new("TEST_SERVER_KEY") }
+    let(:uri) { "#{FCM::INSTANCE_ID_API}/iid/info/#{registration_id}" }
+    let(:mock_request_attributes) { {
+      headers: {
+        'Authorization' => 'key=TEST_SERVER_KEY',
+        'Content-Type' => 'application/json'
+      }
+    } }
+
+    context "without options" do
+      it "calls info endpoint" do
+        endpoint = stub_request(:get, uri).with(mock_request_attributes)
+
+        get_instance_info
+
+        expect(endpoint).to have_been_requested
+      end
+    end
+
+    context "with detail option" do
+      let(:uri) { "#{FCM::INSTANCE_ID_API}/iid/info/#{registration_id}?details=true" }
+      let(:options) {{ details: true }}
+
+      it "calls info endpoint" do
+        endpoint = stub_request(:get, uri).with(mock_request_attributes)
+
+        get_instance_info
+
+        expect(endpoint).to have_been_requested
+      end
+    end
+  end
+
   describe "credentials path" do
     it "can be a path to a file" do
       fcm = FCM.new("test", "README.md")

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -499,38 +499,35 @@ describe FCM do
     # TODO
   end
 
-  describe "getting instance info" do
-    subject(:get_instance_info) { client.get_instance_id_info(registration_id, options) }
+  describe 'getting instance info' do
+    subject(:get_info) { client.get_instance_id_info(registration_id, options) }
 
     let(:options) { nil }
     let(:client) { FCM.new("TEST_SERVER_KEY") }
-    let(:uri) { "#{FCM::INSTANCE_ID_API}/iid/info/#{registration_id}" }
-    let(:mock_request_attributes) { {
-      headers: {
-        'Authorization' => 'key=TEST_SERVER_KEY',
-        'Content-Type' => 'application/json'
-      }
-    } }
+    let(:base_uri) { "#{FCM::INSTANCE_ID_API}/iid/info" }
+    let(:uri) { "#{base_uri}/#{registration_id}" }
+    let(:mock_request_attributes) do
+      { headers: {
+          'Authorization' => 'key=TEST_SERVER_KEY',
+          'Content-Type' => 'application/json'
+      } }
+    end
 
-    context "without options" do
-      it "calls info endpoint" do
+    context 'without options' do
+      it 'calls info endpoint' do
         endpoint = stub_request(:get, uri).with(mock_request_attributes)
-
-        get_instance_info
-
+        get_info
         expect(endpoint).to have_been_requested
       end
     end
 
-    context "with detail option" do
-      let(:uri) { "#{FCM::INSTANCE_ID_API}/iid/info/#{registration_id}?details=true" }
-      let(:options) {{ details: true }}
+    context 'with detail option' do
+      let(:uri) { "#{base_uri}/#{registration_id}?details=true" }
+      let(:options) { { details: true } }
 
-      it "calls info endpoint" do
+      it 'calls info endpoint' do
         endpoint = stub_request(:get, uri).with(mock_request_attributes)
-
-        get_instance_info
-
+        get_info
         expect(endpoint).to have_been_requested
       end
     end


### PR DESCRIPTION
### Issue:
- The FCM API allows for a `detail=true` parameter. This will retrieve topic subscription information.
- The existing `get_instance_id_info` method takes an `options` parameter, but is not being properly passed to the Faraday connection. 
  - what is sent: `https://iid.googleapis.com/iid/info/42?query[details]=true`
  - what is expected: `https://iid.googleapis.com/iid/info/42?details=true`

### Change:
- Update `get_instance_id_info` method to not wrap the `options` with in a hash with `query`