### PR TITLE
Update fcm.gemspec

### DIFF
--- a/fcm.gemspec
+++ b/fcm.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency('faraday', '~> 1')
+  s.add_runtime_dependency('faraday', '>= 1.0.0', '< 3.0')
   s.add_runtime_dependency('googleauth', '~> 1')
 end


### PR DESCRIPTION
[follow up on faraday 2](https://github.com/decision-labs/fcm/issues/99#issuecomment-1061620021):

[quote from the upgrade guide:](https://github.com/lostisland/faraday/blob/main/UPGRADING.md#thats-great-what-should-i-change-in-my-code-immediately-after-upgrading)

> That's great! What should I change in my code immediately after upgrading?
If you just use the default net_http adapter, then you don't need to do anything!