### PR TITLE
Cache authorizer to avoid IO end

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -320,11 +320,11 @@ class FCM
 
   def jwt_token
     scope = "https://www.googleapis.com/auth/firebase.messaging"
-    authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
+    @authorizer ||= Google::Auth::ServiceAccountCredentials.make_creds(
       json_key_io: json_key,
       scope: scope,
     )
-    token = authorizer.fetch_access_token!
+    token = @authorizer.fetch_access_token!
     token["access_token"]
   end
 


### PR DESCRIPTION
Google::Auth::ServiceAccountCredentials.make_creds each call will read json_key_io. Since it cached, second time it read empty string and can't parse JSON.
This caching avoid read each time