### PR TITLE
A refactoring PR of send_v1 method

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -52,10 +52,12 @@ class FCM
 
     post_body = { 'message': message }
     extra_headers = {
-      "Authorization" => "Bearer #{jwt_token}"
+      'Authorization' => "Bearer #{jwt_token}"
     }
     for_uri(BASE_URI_V1, extra_headers) do |connection|
-      response = connection.post("#{@project_name}/messages:send", post_body.to_json)
+      response = connection.post(
+        "#{@project_name}/messages:send", post_body.to_json
+      )
       build_response(response)
     end
   end
@@ -224,7 +226,7 @@ class FCM
     ) do |faraday|
       faraday.adapter Faraday.default_adapter
       faraday.headers["Content-Type"] = "application/json"
-      faraday.headers["Authorization"] = "key=#{@api_key}"
+      faraday.headers['Authorization'] = "key=#{@api_key}"
       extra_headers.each do |key, value|
         faraday.headers[key] = value
       end

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -7,7 +7,6 @@ class FCM
   BASE_URI = "https://fcm.googleapis.com"
   BASE_URI_V1 = "https://fcm.googleapis.com/v1/projects/"
   DEFAULT_TIMEOUT = 30
-  FORMAT = :json
 
   # constants
   GROUP_NOTIFICATION_BASE_URI = "https://android.googleapis.com"

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -8,7 +8,6 @@ class FCM
   BASE_URI_V1 = "https://fcm.googleapis.com/v1/projects/"
   DEFAULT_TIMEOUT = 30
 
-  # constants
   GROUP_NOTIFICATION_BASE_URI = "https://android.googleapis.com"
   INSTANCE_ID_API = "https://iid.googleapis.com"
   TOPIC_REGEX = /[a-zA-Z0-9\-_.~%]+/
@@ -47,7 +46,7 @@ class FCM
   #   }
   # }
   # fcm = FCM.new(api_key, json_key_path, project_name)
-  # fcm.send(
+  # fcm.send_v1(
   #    { "token": "4sdsx",, "to" : "notification": {}.. }
   # )
   def send_notification_v1(message)

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -12,13 +12,11 @@ class FCM
   INSTANCE_ID_API = "https://iid.googleapis.com"
   TOPIC_REGEX = /[a-zA-Z0-9\-_.~%]+/
 
-  attr_accessor :api_key, :json_key_path, :project_base_uri
-
   def initialize(api_key, json_key_path = "", project_name = "", client_options = {})
     @api_key = api_key
     @client_options = client_options
     @json_key_path = json_key_path
-    @project_base_uri = BASE_URI_V1 + project_name.to_s
+    @project_name = project_name
   end
 
   # See https://firebase.google.com/docs/cloud-messaging/send-message
@@ -226,7 +224,7 @@ class FCM
     ) do |faraday|
       faraday.adapter Faraday.default_adapter
       faraday.headers["Content-Type"] = "application/json"
-      faraday.headers["Authorization"] = "key=#{api_key}"
+      faraday.headers["Authorization"] = "key=#{@api_key}"
       extra_headers.each do |key, value|
         faraday.headers[key] = value
       end

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -50,16 +50,16 @@ class FCM
   #    { "token": "4sdsx",, "to" : "notification": {}.. }
   # )
   def send_notification_v1(message)
-    return if @project_base_uri.empty?
+    return if @project_name.empty?
 
     post_body = { 'message': message }
-
-    response = Faraday.post("#{@project_base_uri}/messages:send") do |req|
-      req.headers["Content-Type"] = "application/json"
-      req.headers["Authorization"] = "Bearer #{jwt_token}"
-      req.body = post_body.to_json
+    extra_headers = {
+      "Authorization" => "Bearer #{jwt_token}"
+    }
+    for_uri(BASE_URI_V1, extra_headers) do |connection|
+      response = connection.post("#{@project_name}/messages:send", post_body.to_json)
+      build_response(response)
     end
-    build_response(response)
   end
 
   alias send_v1 send_notification_v1

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -13,7 +13,7 @@ class FCM
   INSTANCE_ID_API = "https://iid.googleapis.com"
   TOPIC_REGEX = /[a-zA-Z0-9\-_.~%]+/
 
-  attr_accessor :timeout, :api_key, :json_key_path, :project_base_uri
+  attr_accessor :api_key, :json_key_path, :project_base_uri
 
   def initialize(api_key, json_key_path = "", project_name = "", client_options = {})
     @api_key = api_key

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -36,24 +36,24 @@ describe FCM do
 
     let(:send_v1_params) do
       {
-        "token" => "4sdsx",
-        "notification" => {
-          "title" => "Breaking News",
-          "body" => "New news story available."
+        'token' => '4sdsx',
+        'notification' => {
+          'title' => 'Breaking News',
+          'body' => 'New news story available.'
         },
-        "data" => {
-          "story_id" => "story_12345"
+        'data' => {
+          'story_id' => 'story_12345'
         },
-        "android" => {
-          "notification" => {
-            "click_action": "TOP_STORY_ACTIVITY",
-            "body" => "Check out the Top Story"
+        'android' => {
+          'notification' => {
+            'click_action' => 'TOP_STORY_ACTIVITY',
+            'body' => 'Check out the Top Story'
           }
         },
-        "apns" => {
-          "payload" => {
-            "aps" => {
-              "category"  => "NEW_MESSAGE_CATEGORY"
+        'apns' => {
+          'payload' => {
+            'aps' => {
+              'category' => 'NEW_MESSAGE_CATEGORY'
             }
           }
         }
@@ -61,13 +61,13 @@ describe FCM do
     end
 
     let(:valid_request_v1_body) do
-      { "message" => send_v1_params }
+      { 'message' => send_v1_params }
     end
 
     let(:stub_fcm_send_v1_request) do
       stub_request(:post, send_v1_url).with(
         body: valid_request_v1_body.to_json,
-        headers: valid_request_v1_headers,
+        headers: valid_request_v1_headers
       ).to_return(
         # ref: https://firebase.google.com/docs/cloud-messaging/http-server-ref#interpret-downstream
         body: "{}",
@@ -86,9 +86,11 @@ describe FCM do
       stub_fcm_send_v1_request
     end
 
-    it "should send notification of HTTP V1 using POST to FCM server" do
+    it 'should send notification of HTTP V1 using POST to FCM server' do
       fcm = FCM.new(api_key, json_key_path, project_name)
-      fcm.send_v1(send_v1_params).should eq(response: "success", body: "{}", headers: {}, status_code: 200)
+      fcm.send_v1(send_v1_params).should eq(
+        response: 'success', body: '{}', headers: {}, status_code: 200
+      )
       stub_fcm_send_v1_request.should have_been_made.times(1)
     end
   end


### PR DESCRIPTION
Just add a few refactoring code, mainly for `#send_v1 `method

1. add rspec test for #send_v1 method
    - preparation for refactoring later

2. refactor #send_v1 method
    - to use the shared `#for_uri(BASE_URI_V1, extra_headers) do end` private method

3. delete unused var / constant / comment

4. delete `attr_accessor :timeout, :api_key, :json_key_path, :project_base_uri`
    - better to encapsulate these attributes within the instance itself instead of being exposed to outside
