### PR TITLE
Adds documentation in the README about how to provide FB credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,41 @@ For Android you will need a device running 2.3 (or newer) that also have the Goo
 A version of supported Ruby, currently:
 `ruby >= 2.4`
 
+## Getting Started
+To use this gem, you need to instantiate a client with your firebase credentials:
+
+```ruby
+fcm = FCM.new(
+  API_TOKEN,
+  GOOGLE_APPLICATION_CREDENTIALS_PATH,
+  FIREBASE_PROJECT_ID
+)
+```
+
+## About the `GOOGLE_APPLICATION_CREDENTIALS_PATH`
+The `GOOGLE_APPLICATION_CREDENTIALS_PATH` is meant to contain your firebase credentials.
+
+The easiest way to provide them is to pass here an absolute path to a file with your credentials:
+
+```ruby
+fcm = FCM.new(
+  API_TOKEN,
+  '/path/to/credentials.json',
+  FIREBASE_PROJECT_ID
+)
+```
+
+As per their secret nature, you might not want to have them in your repository. In that case, another supported solution is to pass a `StringIO` that contains your credentials:
+
+```ruby
+fcm = FCM.new(
+  API_TOKEN,
+  StringIO.new(ENV.fetch('FIREBASE_CREDENTIALS')),
+  FIREBASE_PROJECT_ID
+)
+
+```
+
 ## Usage
 
 ## HTTP v1 API


### PR DESCRIPTION
Hello everyone,

Using `FCM` I've come across the same issue as https://github.com/decision-labs/fcm/issues/110. 
We are a bit confused about how to pass the firebase credentials safely from an ENV variable.

Digging around the lib, I've found two things: 
1. The limitation of passing a file path to `FCM` comes from `googleauth` gem that requires a `json_key_io` responding to `#read` ([source](https://github.com/googleapis/google-auth-library-ruby/blob/1354b076a159d223b737e5b1f27dde0463eb5292/lib/googleauth/json_key_reader.rb#L19)).
2. This lib is clever enough to use any IO responding to `#read` as credentials instead of a file path

Only thing is that the usage of an IO is a bit hidden in the test suite [here](https://github.com/decision-labs/fcm/blob/07941b322e5922be6545d0809e9ee17b5f4e350d/spec/fcm_spec.rb#L604) or in the codebase [here](https://github.com/decision-labs/fcm/blob/07941b322e5922be6545d0809e9ee17b5f4e350d/lib/fcm.rb#L330).

So here I am suggesting adding a small part about it in the readme. 

Feel free to ask for a rewording or more details.