### PR TITLE
Expose the jwt-token method

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -217,6 +217,16 @@ class FCM
     end
   end
 
+  def jwt_token
+    scope = "https://www.googleapis.com/auth/firebase.messaging"
+    @authorizer ||= Google::Auth::ServiceAccountCredentials.make_creds(
+      json_key_io: json_key,
+      scope: scope,
+    )
+    token = @authorizer.fetch_access_token!
+    token["access_token"]
+  end
+
   private
 
   def for_uri(uri, extra_headers = {})
@@ -314,16 +324,6 @@ class FCM
   def validate_condition_topics?(condition)
     topics = condition.scan(/(?:^|\S|\s)'([^']*?)'(?:$|\S|\s)/).flatten
     topics.all? { |topic| topic.gsub(TOPIC_REGEX, "").length == 0 }
-  end
-
-  def jwt_token
-    scope = "https://www.googleapis.com/auth/firebase.messaging"
-    @authorizer ||= Google::Auth::ServiceAccountCredentials.make_creds(
-      json_key_io: json_key,
-      scope: scope,
-    )
-    token = @authorizer.fetch_access_token!
-    token["access_token"]
   end
 
   def json_key


### PR DESCRIPTION
So that its easy for consumers of the FCM gem to make custom requests directly to the firebase http API's if/when required

Such as hitting the `https://iid.googleapis.com/iid/v1:batchImport` endpoint to bulk import and convert apns tokens to FCM tokens: https://developers.google.com/instance-id/reference/server#create_registration_tokens_for_apns_tokens