### PR TITLE
Create a specific CHANGELOG.md file and set changelog_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+## ChangeLog
+
+### 2.0.0
+#### Breaking Changes
+- Remove deprecated `API_KEY`
+- Remove deprecated `send` method
+- Remove deprecated `send_with_notification_key` method
+- Remove `subscribe_instance_id_to_topic` method
+- Remove `unsubscribe_instance_id_from_topic` method
+- Remove `batch_subscribe_instance_ids_to_topic` method
+- Remove `batch_unsubscribe_instance_ids_from_topic` method
+
+#### Supported Features
+- Add HTTP v1 API support for `send_to_topic_condition` method
+- Add HTTP v1 API support for `send_to_topic` method
+
+### 1.0.8
+- caches calls to `Google::Auth::ServiceAccountCredentials` #103
+- Allow `faraday` versions from 1 up to 2  #101
+
+### 1.0.7
+
+- Fix passing `DEFAULT_TIMEOUT` to `faraday` [#96](https://github.com/decision-labs/fcm/pull/96)
+- Fix issue with `get_instance_id_info` option params [#98](https://github.com/decision-labs/fcm/pull/98)
+- Accept any IO object for credentials [#95](https://github.com/decision-labs/fcm/pull/94)
+
+Huge thanks to @excid3 @jsparling @jensljungblad
+
+### 1.0.3
+
+- Fix overly strict faraday dependency
+
+### 1.0.2
+
+- Bug fix: retrieve notification key" params: https://github.com/spacialdb/fcm/commit/b328a75c11d779a06d0ceda83527e26aa0495774
+
+### 1.0.0
+
+- Bumped supported ruby to `>= 2.4`
+- Fix deprecation warnings from `faraday` by changing dependency version to `faraday 1.0.0`
+
+### 0.0.7
+
+- replace `httparty` with `faraday`
+
+### 0.0.2
+
+- Fixed group messaging url.
+- Added API to `recover_notification_key`.
+
+
+### 0.0.1
+
+- Initial version.

--- a/README.md
+++ b/README.md
@@ -272,61 +272,6 @@ You can find a guide to implement an Android Client app to receive notifications
 
 The guide to set up an iOS app to get notifications is here: [Setting up a FCM Client App on iOS](https://firebase.google.com/docs/cloud-messaging/ios/client).
 
-## ChangeLog
-
-### 2.0.0
-#### Breaking Changes
-- Remove deprecated `API_KEY`
-- Remove deprecated `send` method
-- Remove deprecated `send_with_notification_key` method
-- Remove `subscribe_instance_id_to_topic` method
-- Remove `unsubscribe_instance_id_from_topic` method
-- Remove `batch_subscribe_instance_ids_to_topic` method
-- Remove `batch_unsubscribe_instance_ids_from_topic` method
-
-#### Supported Features
-- Add HTTP v1 API support for `send_to_topic_condition` method
-- Add HTTP v1 API support for `send_to_topic` method
-
-### 1.0.8
-- caches calls to `Google::Auth::ServiceAccountCredentials` #103
-- Allow `faraday` versions from 1 up to 2  #101
-
-### 1.0.7
-
-- Fix passing `DEFAULT_TIMEOUT` to `faraday` [#96](https://github.com/decision-labs/fcm/pull/96)
-- Fix issue with `get_instance_id_info` option params [#98](https://github.com/decision-labs/fcm/pull/98)
-- Accept any IO object for credentials [#95](https://github.com/decision-labs/fcm/pull/94)
-
-Huge thanks to @excid3 @jsparling @jensljungblad
-
-### 1.0.3
-
-- Fix overly strict faraday dependency
-
-### 1.0.2
-
-- Bug fix: retrieve notification key" params: https://github.com/spacialdb/fcm/commit/b328a75c11d779a06d0ceda83527e26aa0495774
-
-### 1.0.0
-
-- Bumped supported ruby to `>= 2.4`
-- Fix deprecation warnings from `faraday` by changing dependency version to `faraday 1.0.0`
-
-### 0.0.7
-
-- replace `httparty` with `faraday`
-
-### 0.0.2
-
-- Fixed group messaging url.
-- Added API to `recover_notification_key`.
-
-
-### 0.0.1
-
-- Initial version.
-
 ## MIT License
 
 - Copyright (c) 2016 Kashif Rasul and Shoaib Burq. See LICENSE.txt for details.
@@ -337,7 +282,7 @@ Huge thanks to @excid3 @jsparling @jensljungblad
 
 ## Cutting a release
 
-Update version in `fcm.gemspec` with `VERSION` and update `README.md` `## ChangeLog` section.
+Update version in `fcm.gemspec` with `VERSION` and update `CHANGELOG.md`.
 
 ```bash
 # set the version

--- a/fcm.gemspec
+++ b/fcm.gemspec
@@ -1,24 +1,32 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+
+$:.push File.expand_path('../lib', __FILE__)
+
+REPOSITORY_URI = 'https://github.com/decision-labs/fcm'
 
 Gem::Specification.new do |s|
-  s.name = "fcm"
-  s.version = "2.0.0"
-  s.platform = Gem::Platform::RUBY
-  s.authors = ["Kashif Rasul", "Shoaib Burq"]
-  s.email = ["kashif@decision-labs.com", "shoaib@decision-labs.com"]
-  s.homepage = "https://github.com/decision-labs/fcm"
-  s.summary = %q{Reliably deliver messages and notifications via FCM}
+  s.name        = 'fcm'
+  s.version     = '2.0.0'
+  s.platform    = Gem::Platform::RUBY
+  s.authors     = ['Kashif Rasul', 'Shoaib Burq']
+  s.email       = ['kashif@decision-labs.com', 'shoaib@decision-labs.com']
+  s.homepage    = REPOSITORY_URI
+  s.summary     = %q{Reliably deliver messages and notifications via FCM}
   s.description = %q{fcm provides ruby bindings to Firebase Cloud Messaging (FCM) a cross-platform messaging solution that lets you reliably deliver messages and notifications at no cost to Android, iOS or Web browsers.}
-  s.license = "MIT"
+  s.license     = 'MIT'
+  s.metadata    = {
+    'homepage_uri' => REPOSITORY_URI,
+    'changelog_uri' => "#{REPOSITORY_URI}/blob/master/CHANGELOG.md",
+    'source_code_uri' => REPOSITORY_URI
+  }
 
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = '>= 2.4.0'
 
-  s.files = `git ls-files`.split("\n")
-  s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.files = `git ls-files`.split('\n')
+  s.test_files = `git ls-files -- {test,spec,features}/*`.split('\n')
+  s.executables = `git ls-files -- bin/*`.split('\n').map { |f| File.basename(f) }
+  s.require_paths = ['lib']
 
-  s.add_runtime_dependency("faraday", ">= 1.0.0", "< 3.0")
-  s.add_runtime_dependency("googleauth", "~> 1")
+  s.add_runtime_dependency('faraday', '>= 1.0.0', '< 3.0')
+  s.add_runtime_dependency('googleauth', '~> 1')
 end


### PR DESCRIPTION
Hey 👋

Thank you very much for your gem.
I realized that the changelog was located at the very bottom of the readme. Therefore, I would like to propose a few changes:
- Creation of a dedicated CHANGELOG.md file to follow best practices
- Definition of the changelog_uri so the changelog can be found more easily, for example by GemUpdater.

Thank you!