### PR TITLE
Ensure JSON Key Path is an Actual File or IO Object

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -293,23 +293,25 @@ class FCM
     token["access_token"]
   end
 
-  def credentials_error_msg(json_key_path)
-    param_klass = if @json_key_path.nil?
-      'nil'
-    else
-      "a #{@json_key_path.class.name}"
-    end
+  def credentials_error_msg(param)
+    error_msg = 'credentials must be an IO-like ' \
+      'object or path You passed '
 
-    "credentials must be an IO-like object or a path. You passed #{param_klass}"
+    error_msg += param.class.name.to_s
+    raise InvalidCredentialError, error_msg
+  end
+
+  def filename_or_io_like?(path)
+    (path.is_a?(String) || path.respond_to?(:open)) && File.file?(path)
   end
 
   def json_key
     @json_key ||= if @json_key_path.respond_to?(:read)
-      @json_key_path
-    elsif (@json_key_path.is_a?(String) || @json_key_path.respond_to?(:open)) && File.file?(@json_key_path)
-      File.open(@json_key_path)
-    else
-      raise InvalidCredentialError, credentials_error_msg(@json_key_path)
-    end
+                    @json_key_path
+                  elsif filename_or_io_like?(@json_key_path)
+                    File.open(@json_key_path)
+                  else
+                    credentials_error_msg(@json_key_path)
+                  end
   end
 end

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -302,7 +302,7 @@ class FCM
     raise InvalidCredentialError, error_msg
   end
 
-  def open_json_key_path?(path)
+  def valid_json_key_path?(path)
     valid_io_object = path.respond_to?(:open)
     return true if valid_io_object && File.file?(path)
 
@@ -314,7 +314,7 @@ class FCM
   def json_key
     @json_key ||= if @json_key_path.respond_to?(:read)
                     @json_key_path
-                  elsif open_json_key_path?(@json_key_path)
+                  elsif valid_json_key_path?(@json_key_path)
                     File.open(@json_key_path)
                   else
                     credentials_error_msg(@json_key_path)

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -295,20 +295,26 @@ class FCM
 
   def credentials_error_msg(param)
     error_msg = 'credentials must be an IO-like ' \
-      'object or path You passed '
+      'object or path. You passed'
 
-    error_msg += param.class.name.to_s
+    param_klass = param.nil? ? 'nil' : "a #{param.class.name}"
+    error_msg += " #{param_klass}."
     raise InvalidCredentialError, error_msg
   end
 
-  def filename_or_io_like?(path)
-    (path.is_a?(String) || path.respond_to?(:open)) && File.file?(path)
+  def open_json_key_path?(path)
+    valid_io_object = path.respond_to?(:open)
+    return true if valid_io_object && File.file?(path)
+
+    max_path_len = 1024
+    valid_path = path.is_a?(String) && path.length <= max_path_len
+    valid_path && File.file?(path)
   end
 
   def json_key
     @json_key ||= if @json_key_path.respond_to?(:read)
                     @json_key_path
-                  elsif filename_or_io_like?(@json_key_path)
+                  elsif open_json_key_path?(@json_key_path)
                     File.open(@json_key_path)
                   else
                     credentials_error_msg(@json_key_path)

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -293,7 +293,7 @@ class FCM
     token["access_token"]
   end
 
-  def credentials_error_msg(param)
+  def raise_credentials_error(param)
     error_msg = 'credentials must be an IO-like ' \
       'object or path. You passed'
 
@@ -317,7 +317,7 @@ class FCM
                   elsif valid_json_key_path?(@json_key_path)
                     File.open(@json_key_path)
                   else
-                    credentials_error_msg(@json_key_path)
+                    raise_credentials_error(@json_key_path)
                   end
   end
 end

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -13,18 +13,33 @@ describe FCM do
     }
   end
 
+  let(:client_email) do
+    '83315528762cf7e0-7bbcc3aad87e0083391bc7f234d487' \
+    'c8@developer.gserviceaccount.com'
+  end
+
+  let(:client_x509_cert_url) do
+    'https://www.googleapis.com/robot/v1/metadata/x509/' \
+    'fd6b61037dd2bb8585527679" + "-7bbcc3aad87e0083391b' \
+    'c7f234d487c8%40developer.gserviceaccount.com'
+  end
+
+  let(:creds_error) do
+    FCM::InvalidCredentialError
+  end
+
   let(:json_credentials) do
     {
       "type": 'service_account',
       "project_id": 'example',
       "private_key_id": 'c09c4593eee53707ca9f4208fbd6fe72b29fc7ab',
       "private_key": OpenSSL::PKey::RSA.new(2048),
-      "client_email": '83315528762cf7e0-7bbcc3aad87e0083391bc7f234d487c8@developer.gserviceaccount.com',
-      "client_id": 'acedc3c0a63b3562376386f0-f3b94aafbecd0e7d60563bf7bb8bb47f.apps.googleusercontent.com',
+      "client_email": client_email,
+      "client_id": 'acedc3c0a63b3562376386f0.apps.googleusercontent.com',
       "auth_uri": 'https://accounts.google.com/o/oauth2/auth',
       "token_uri": 'https://oauth2.googleapis.com/token',
       "auth_provider_x509_cert_url": 'https://www.googleapis.com/oauth2/v1/certs',
-      "client_x509_cert_url": 'https://www.googleapis.com/robot/v1/metadata/x509/fd6b61037dd2bb8585527679-7bbcc3aad87e0083391bc7f234d487c8%40developer.gserviceaccount.com',
+      "client_x509_cert_url": client_x509_cert_url,
       "universe_domain": 'googleapis.com'
     }.to_json
   end
@@ -42,35 +57,34 @@ describe FCM do
   end
 
   describe "credentials path" do
-    it "can be a path to a file" do
+    it 'can be a path to a file' do
       fcm = FCM.new("README.md")
       expect(fcm.__send__(:json_key).class).to eq(File)
     end
 
-    it "can be an IO object" do
-      fcm = FCM.new(StringIO.new("hey"))
+    it 'can be an IO object' do
+      fcm = FCM.new(StringIO.new('hey'))
       expect(fcm.__send__(:json_key).class).to eq(StringIO)
     end
 
-    it "raises an error when passed a non-existent credentials file path" do
-      fcm = FCM.new('spec/fake_credentials.json', '', {})
-      expect { fcm.__send__(:json_key).class }.to raise_error(FCM::InvalidCredentialError)
-    end
-
-    it "raises an error when passed a string of a file that does not exist" do
-      fcm = FCM.new("fake_credentials.json", '', {})
-      expect { fcm.__send__(:json_key).class }.to raise_error(FCM::InvalidCredentialError)
-    end
-
     it 'raises an error when passed a non IO-like object' do
-      fcm_with_non_io_objects = [
-        fcm_with_nil_creds = FCM.new(nil, '', {}),
-        fcm_with_hash_creds = FCM.new({}, '', {}),
-        fcm_with_json = FCM.new(json_credentials, '', {})
-      ]
-      fcm_with_non_io_objects.each do |fcm_with_non_io_object|
-        expect { fcm_with_non_io_object.__send__(:json_key).class }.to raise_error(FCM::InvalidCredentialError)
+      [
+        FCM.new(nil, '', {}),
+        FCM.new({}, '', {}),
+        FCM.new(json_credentials, '', {})
+      ].each do |fcm|
+        expect { fcm.__send__(:json_key) }.to raise_error(creds_error)
       end
+    end
+
+    it 'raises an error when passed a non-existent credentials file path' do
+      fcm = FCM.new('spec/fake_credentials.json', '', {})
+      expect { fcm.__send__(:json_key) }.to raise_error(creds_error)
+    end
+
+    it 'raises an error when passed a string of a file that does not exist' do
+      fcm = FCM.new('fake_credentials.json', '', {})
+      expect { fcm.__send__(:json_key) }.to raise_error(creds_error)
     end
   end
 


### PR DESCRIPTION
Currently, in the [json_key](https://github.com/decision-labs/fcm/blob/master/lib/fcm.rb#L294) method it assumes that json_key_path will be an IO-like object or filename. This can cause an issue where if someone accidentally passes credentials in plaintext or a non-IO object, the Gem will attempt to open the credentials and display the credentials in plain text.

This PR resolves https://github.com/decision-labs/fcm/issues/133.