### PR TITLE
Allow faraday client configuration

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -12,10 +12,11 @@ class FCM
   INSTANCE_ID_API = "https://iid.googleapis.com"
   TOPIC_REGEX = /[a-zA-Z0-9\-_.~%]+/
 
-  def initialize(json_key_path = "", project_name = "", http_options = {})
+  def initialize(json_key_path = "", project_name = "", http_options = {}, faraday_configurer = nil)
     @json_key_path = json_key_path
     @project_name = project_name
     @http_options = http_options
+    @faraday_configurer = faraday_configurer
   end
 
   # See https://firebase.google.com/docs/cloud-messaging/send-message
@@ -202,6 +203,7 @@ class FCM
       extra_headers.each do |key, value|
         faraday.headers[key] = value
       end
+      @faraday_configurer.call(faraday) if @faraday_configurer
     end
     yield connection
   end

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -37,6 +37,17 @@ describe FCM do
     end
   end
 
+  describe 'faraday configurer' do
+    let(:configurer) { ->(faraday) { } }
+    let(:client) { FCM.new(json_key_path, '', {}, configurer) }
+
+    it 'should be called when initializing faraday client' do
+      expect(configurer).to receive(:call).with(Faraday::Connection)
+
+      client.__send__(:for_uri, '') {}
+    end
+  end
+
   describe "#send_v1 or #send_notification_v1" do
     let(:client) { FCM.new(json_key_path, project_name) }
 


### PR DESCRIPTION
Enable additional configuration of Faraday client, allowing usage of different Faraday middleware.

This PR also partially resolves https://github.com/decision-labs/fcm/issues/59, as it allows configuring retry middleware.