### PR TITLE
feat: configurable open_timeout via http_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ fcm = FCM.new(
 
 ```
 
+## Request timeouts
+
+Both the read timeout and the TCP connect timeout are configurable via
+`http_options`. Both default to `DEFAULT_TIMEOUT` (30s):
+
+```ruby
+fcm = FCM.new(
+  GOOGLE_APPLICATION_CREDENTIALS_PATH,
+  FIREBASE_PROJECT_ID,
+  timeout: 10,      # response read timeout
+  open_timeout: 5   # TCP connect timeout — fail fast on stuck handshakes
+)
+```
+
 ## Usage
 
 ## HTTP v1 API

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -195,7 +195,10 @@ class FCM
   def for_uri(uri, extra_headers = {})
     connection = ::Faraday.new(
       url: uri,
-      request: { timeout: @http_options.fetch(:timeout, DEFAULT_TIMEOUT) }
+      request: {
+        timeout: @http_options.fetch(:timeout, DEFAULT_TIMEOUT),
+        open_timeout: @http_options.fetch(:open_timeout, DEFAULT_TIMEOUT),
+      }
     ) do |faraday|
       faraday.adapter Faraday.default_adapter
       faraday.headers["Content-Type"] = "application/json"

--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -199,7 +199,7 @@ class FCM
       url: uri,
       request: {
         timeout: @http_options.fetch(:timeout, DEFAULT_TIMEOUT),
-        open_timeout: @http_options.fetch(:open_timeout, DEFAULT_TIMEOUT),
+        open_timeout: @http_options.fetch(:open_timeout, DEFAULT_TIMEOUT)
       }
     ) do |faraday|
       faraday.adapter Faraday.default_adapter

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -517,9 +517,9 @@ describe FCM do
     end
   end
 
-  describe 'request timeouts' do
-    it 'defaults timeout and open_timeout to DEFAULT_TIMEOUT' do
-      fcm = FCM.new(json_key_path, project_name)
+  describe "request timeouts" do
+    it "defaults timeout and open_timeout to DEFAULT_TIMEOUT" do
+      fcm = described_class.new(json_key_path, project_name)
       allow(fcm).to receive(:json_key)
 
       fcm.__send__(:for_uri, FCM::BASE_URI_V1) do |conn|
@@ -528,8 +528,8 @@ describe FCM do
       end
     end
 
-    it 'honours :timeout and :open_timeout from http_options' do
-      fcm = FCM.new(json_key_path, project_name, timeout: 7, open_timeout: 3)
+    it "honours :timeout and :open_timeout from http_options" do
+      fcm = described_class.new(json_key_path, project_name, timeout: 7, open_timeout: 3)
       allow(fcm).to receive(:json_key)
 
       fcm.__send__(:for_uri, FCM::BASE_URI_V1) do |conn|

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -514,4 +514,26 @@ describe FCM do
       end
     end
   end
+
+  describe 'request timeouts' do
+    it 'defaults timeout and open_timeout to DEFAULT_TIMEOUT' do
+      fcm = FCM.new(json_key_path, project_name)
+      allow(fcm).to receive(:json_key)
+
+      fcm.__send__(:for_uri, FCM::BASE_URI_V1) do |conn|
+        expect(conn.options.timeout).to eq(FCM::DEFAULT_TIMEOUT)
+        expect(conn.options.open_timeout).to eq(FCM::DEFAULT_TIMEOUT)
+      end
+    end
+
+    it 'honours :timeout and :open_timeout from http_options' do
+      fcm = FCM.new(json_key_path, project_name, timeout: 7, open_timeout: 3)
+      allow(fcm).to receive(:json_key)
+
+      fcm.__send__(:for_uri, FCM::BASE_URI_V1) do |conn|
+        expect(conn.options.timeout).to eq(7)
+        expect(conn.options.open_timeout).to eq(3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The `:timeout` `http_option` already controlled the Faraday request timeout, but `open_timeout` (TCP connect timeout) fell back to net-http's default of 60s — too long for high-volume push pipelines where a stuck handshake should fail fast and let the caller retry.

This PR adds a `:open_timeout` `http_option`, defaulting to `DEFAULT_TIMEOUT` (30s) to preserve current effective behaviour for callers that don't set it, while letting busy senders override it:

```ruby
fcm = FCM.new(
  GOOGLE_APPLICATION_CREDENTIALS_PATH,
  FIREBASE_PROJECT_ID,
  timeout: 10,      # response read timeout
  open_timeout: 5   # TCP connect timeout — fail fast on stuck handshakes
)
```

## Test plan

- [x] Existing 29 specs pass unchanged.
- [x] New specs cover: defaults to `DEFAULT_TIMEOUT`, honours `:timeout` and `:open_timeout` overrides.