### PR TITLE
ci: cover modern Ruby versions in test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.3']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
## Summary

Adds **3.2**, **3.4** and **4.0** to the CI test matrix.

| Ruby | Status | Was in CI? |
|---|---|---|
| 2.7 | EOL 2023-03 | yes |
| 3.0 | EOL 2024-03 | yes |
| 3.1 | EOL 2025-03 | yes |
| **3.2** | in support, EOL 2026-03-31 | **no — added** |
| 3.3 | in support | yes |
| **3.4** | latest stable (released 2024-12-25) | **no — added** |
| **4.0** | released 2026 | **no — added** |

Additive only — existing entries are kept since the gemspec still declares `s.required_ruby_version = ">= 2.4.0"`. Dropping the EOL Rubies would be a separate decision.

## Test plan

- [x] Verified locally on Ruby 4.0.2: 29/29 specs pass.
- [ ] CI itself will exercise the new versions on this PR.